### PR TITLE
Potential fix for code scanning alert no. 49: Log injection

### DIFF
--- a/server/logger/cloudLogging.ts
+++ b/server/logger/cloudLogging.ts
@@ -4,7 +4,10 @@ import { AuditLog } from "../interfaces/logger";
 type LoggingClient = import("@google-cloud/logging").Logging;
 
 export function formatLogMessage(text: string): string {
-    const message = text.replace(/[^\x20-\x7E\r\n]+/g, "");
+    const message = String(text)
+        .substring(0, 1000)
+        .replace(/[\r\n]+/g, " ")
+        .replace(/[^\x20-\x7E]+/g, "");
     const logFormat = "AUDIT_LOG: message";
     return logFormat.replace("message", message);
 }
@@ -36,8 +39,7 @@ export default class AuditLogger {
     }
 
     error(logger: IncomingMessage["log"], message: string): void {
-        const sanitized = String(message).substring(0, 1000).replace(/[^\x20-\x7E\r\n]+/g, "");
-        const log = formatLogMessage(sanitized);
+        const log = formatLogMessage(message);
         logger.error(log);
     }
 


### PR DESCRIPTION
Potential fix for [https://github.com/ONSdigital/blaise-access-management/security/code-scanning/49](https://github.com/ONSdigital/blaise-access-management/security/code-scanning/49)

The best fix is to **centralize strict log sanitization in `server/logger/cloudLogging.ts`** so every call to `auditLogger.info` and `auditLogger.error` is protected without changing route behavior.

Specifically:
- Update `formatLogMessage` to:
  - Coerce to string
  - Remove `\r` and `\n` (and optionally tabs) to prevent line injection
  - Keep printable ASCII filtering
  - Apply the same max-length guard used by `error` (e.g., 1000 chars)
- Update `error` to rely on the same centralized sanitizer path (avoid duplicated, inconsistent sanitization logic).

This single-file change fixes all listed variants because they all flow through `auditLogger.info/error` into `formatLogMessage`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
